### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/0xC000005/PyChebyshev/security/code-scanning/1](https://github.com/0xC000005/PyChebyshev/security/code-scanning/1)

In general, to fix this problem you should explicitly declare a `permissions:` block that grants only the minimal needed scopes to the `GITHUB_TOKEN`. This can be set at the workflow root (applies to all jobs without their own block) or per-job. For this workflow, none of the steps require write access to the repository; they only need to read the code, so `contents: read` is sufficient. The Codecov upload uses an explicit `secrets.CODECOV_TOKEN`, not `GITHUB_TOKEN`, so it does not require extra GitHub token scopes.

The best minimal fix without changing functionality is to add a workflow-level `permissions:` block immediately after the `name: Tests` line (or before `jobs:`), setting `contents: read`. This will restrict the `GITHUB_TOKEN` to read-only repository contents while leaving all existing steps functional. No additional imports or methods are required because this is a YAML configuration change only.

Concretely:
- Edit `.github/workflows/test.yml`.
- After line 1 (`name: Tests`), insert:

  ```yml
  permissions:
    contents: read
  ```

No other lines need to be changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
